### PR TITLE
Fix allocation strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,8 @@ Testing on rinkeby has been deprecated.
 | Contract | Info | Address |
 |---------------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------|
 | rDAI proxy | Use this address in your dapp | [0x261b45D85cCFeAbb11F022eBa346ee8D1cd488c0](https://etherscan.io/address/0x261b45d85ccfeabb11f022eba346ee8d1cd488c0) |
-| rToken logic | Version 1.0.1-rc2 | [0x806a196872Beff0CDE5663cbc1d8962309444932](https://etherscan.io/address/0x806a196872beff0cde5663cbc1d8962309444932) |
-| Allocation Strategy | Compound | [0xd0810DeE68dD9aEAfc2dBC2A6f53C3809A2E6578](https://etherscan.io/address/0xd0810dee68dd9aeafc2dbc2a6f53c3809a2e6578) |
+| rToken logic | Version 1.0.1-rc2 | [0x56b481bA9f338144Fa40C84fb0F4C87B9f4d6dFE](https://etherscan.io/address/0x56b481bA9f338144Fa40C84fb0F4C87B9f4d6dFE) |
+| Allocation Strategy | Compound | [0xbB16307aaed1e070B3C4465d4FDa5E518bDc2433](https://etherscan.io/address/0xbB16307aaed1e070B3C4465d4FDa5E518bDc2433) |
 | Underlying token | DAI | [0x6B175474E89094C44Da98b954EedeAC495271d0F](https://etherscan.io/address/0x6B175474E89094C44Da98b954EedeAC495271d0F) |
 | Allocation token | cDAI | [0x5d3a536e4d6dbd6114cc1ead35777bab948e3643](https://etherscan.io/address/0x5d3a536e4d6dbd6114cc1ead35777bab948e3643) |
 

--- a/contracts/CompoundAllocationStrategy.sol
+++ b/contracts/CompoundAllocationStrategy.sol
@@ -48,13 +48,22 @@ contract CompoundAllocationStrategy is IAllocationStrategy, Ownable {
     function redeemUnderlying(uint256 redeemAmount) external onlyOwner returns (uint256) {
         uint256 cTotalBefore = cToken.totalSupply();
         // TODO should we handle redeem failure?
-        require(cToken.redeemUnderlying(redeemAmount) == 0, "redeemUnderlying failed");
+        require(cToken.redeemUnderlying(redeemAmount) == 0, "cToken.redeemUnderlying failed");
         uint256 cTotalAfter = cToken.totalSupply();
         uint256 cBurnedAmount;
         require(cTotalAfter <= cTotalBefore, "Compound redeemed negative amount!?");
         cBurnedAmount = cTotalBefore - cTotalAfter;
         token.transfer(msg.sender, redeemAmount);
         return cBurnedAmount;
+    }
+
+    /// @dev ISavingStrategy.redeemAll implementation
+    function redeemAll() external onlyOwner
+        returns (uint256 savingsAmount, uint256 underlyingAmount) {
+        savingsAmount = cToken.balanceOf(address(this));
+        require(cToken.redeem(savingsAmount) == 0, "cToken.redeem failed");
+        underlyingAmount = token.balanceOf(address(this));
+        token.transfer(msg.sender, underlyingAmount);
     }
 
 }

--- a/contracts/IAllocationStrategy.sol
+++ b/contracts/IAllocationStrategy.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.8;
  * @notice Allocation strategy for assets.
  *         - It invests the underlying assets into some yield generating contracts,
  *           usually lending contracts, in return it gets new assets aka. saving assets.
- *         - Sainv assets can be redeemed back to the underlying assets plus interest any time.
+ *         - Savings assets can be redeemed back to the underlying assets plus interest any time.
  */
 interface IAllocationStrategy {
 
@@ -47,5 +47,13 @@ interface IAllocationStrategy {
      * @return uint256 Amount of saving assets burned
      */
     function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
+
+    /**
+     * @notice Owner redeems all saving assets
+     * @dev Interst shall be accrued
+     * @return uint256 savingsAmount Amount of savings redeemed
+     * @return uint256 underlyingAmount Amount of underlying redeemed
+     */
+    function redeemAll() external returns (uint256 savingsAmount, uint256 underlyingAmount);
 
 }

--- a/contracts/RToken.sol
+++ b/contracts/RToken.sol
@@ -426,10 +426,11 @@ contract RToken is
         IAllocationStrategy oldIas = ias;
         ias = allocationStrategy;
         // redeem everything from the old strategy
-        uint256 sOriginalBurned = oldIas.redeemUnderlying(totalSupply);
+        (uint256 sOriginalBurned, ) = oldIas.redeemAll();
+        uint256 totalAmount = token.balanceOf(address(this));
         // invest everything into the new strategy
-        require(token.approve(address(ias), totalSupply), "token approve failed");
-        uint256 sOriginalCreated = ias.investUnderlying(totalSupply);
+        require(token.approve(address(ias), totalAmount), "token approve failed");
+        uint256 sOriginalCreated = ias.investUnderlying(totalAmount);
 
         // calculate new saving asset conversion rate
         //

--- a/contracts/RToken.sol
+++ b/contracts/RToken.sol
@@ -432,6 +432,17 @@ contract RToken is
         require(token.approve(address(ias), totalAmount), "token approve failed");
         uint256 sOriginalCreated = ias.investUnderlying(totalAmount);
 
+        // give back the ownership of the old allocation strategy to the admin
+        // unless we are simply switching to the same allocaiton Strategy
+        //
+        //  - But why would we switch to the same allocation strategy?
+        //  - This is a special case where one could pick up the unsoliciated
+        //    savings from the allocation srategy contract as extra "interest"
+        //    for all rToken holders.
+        if (address(ias) != address(oldIas)) {
+            Ownable(address(oldIas)).transferOwnership(address(owner()));
+        }
+
         // calculate new saving asset conversion rate
         //
         // NOTE:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rtoken/contracts",
-    "version": "1.0.1-rc3",
+    "version": "1.0.1-rc4",
     "description": "RToken Ethereum contracts",
     "license": "MIT",
     "dependencies": {

--- a/scripts/deploy-rdai-logic.js
+++ b/scripts/deploy-rdai-logic.js
@@ -7,11 +7,7 @@ module.exports = async function (callback) {
 
         const { web3tx } = require("@decentral.ee/web3-test-helpers");
         const RToken = artifacts.require("rDAI");
-        const rDaiLogic = await web3tx(RToken.new, "RToken.new")(
-            {
-                gas: 5000000,
-            }
-        );
+        const rDaiLogic = await web3tx(RToken.new, "RToken.new")();
         console.log("rDaiLogic deployed at: ", rDaiLogic.address);
 
         callback();

--- a/scripts/deploy-rdai.js
+++ b/scripts/deploy-rdai.js
@@ -26,7 +26,7 @@ module.exports = async function (callback) {
         const RDAI = artifacts.require("rDAI");
         const Proxy = artifacts.require("Proxy");
 
-        const addresses = await require("./addresses")[network];
+        const addresses = require("./addresses")[network];
 
         let compoundASAddress = await promisify(rl.question)("Specify a deployed CompoundAllocationStrategy (deploy a new one if blank): ");
         let compoundAS;
@@ -34,9 +34,7 @@ module.exports = async function (callback) {
             compoundAS = await web3tx(
                 CompoundAllocationStrategy.new,
                 `CompoundAllocationStrategy.new cDAI ${addresses.cDAI}`)(
-                addresses.cDAI, {
-                    gas: 1000000,
-                }
+                addresses.cDAI
             );
             console.log("compoundAllocationStrategy deployed at: ", compoundAS.address);
         } else {
@@ -46,11 +44,7 @@ module.exports = async function (callback) {
         let rDAIAddress = await promisify(rl.question)("Specify a deployed rDAI (deploy a new one if blank): ");
         let rDAI;
         if (!rDAIAddress) {
-            rDAI = await web3tx(RDAI.new, "rDAI.new")(
-                {
-                    gas: 5000000,
-                }
-            );
+            rDAI = await web3tx(RDAI.new, "rDAI.new")();
             console.log("rDAI deployed at: ", rDAI.address);
         } else {
             rDAI = await RDAI.at(rDAIAddress);
@@ -59,9 +53,7 @@ module.exports = async function (callback) {
         const rDaiConstructCode = rDAI.contract.methods.initialize(compoundAS.address).encodeABI();
         console.log(`rDaiConstructCode rDAI.initialize(${rDaiConstructCode})`);
         const proxy = await web3tx(Proxy.new, "Proxy.new")(
-            rDaiConstructCode, rDAI.address, {
-                gas: 1000000,
-            }
+            rDaiConstructCode, rDAI.address
         );
         console.log("proxy deployed at: ", proxy.address);
 

--- a/scripts/deploy-rsai-logic.js
+++ b/scripts/deploy-rsai-logic.js
@@ -7,11 +7,7 @@ module.exports = async function (callback) {
 
         const { web3tx } = require("@decentral.ee/web3-test-helpers");
         const rSAI = artifacts.require("rSAI");
-        const rSAILogic = await web3tx(rSAI.new, "rSAI.new")(
-            {
-                gas: 5000000,
-            }
-        );
+        const rSAILogic = await web3tx(rSAI.new, "rSAI.new")();
         console.log("rSAILogic deployed at: ", rSAILogic.address);
 
         callback();


### PR DESCRIPTION
add IAS.redeemAll function

In order to switch allocatraion strategy and drain all funds from the old startegy, IAS.redeemAll is a more clean way of achieving it.

- test case improved wrt allocation strategy switching
